### PR TITLE
Improved desired and current zoom comparison

### DIFF
--- a/Source/SmoothZoom/Private/AC_SmoothZoom.cpp
+++ b/Source/SmoothZoom/Private/AC_SmoothZoom.cpp
@@ -24,7 +24,7 @@ void UAC_SmoothZoom::TickComponent( float DeltaTime, ELevelTick TickType, FActor
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 
 	// Only call when need to, saves ms's 
-	if (SpringArm->TargetArmLength != DesiredArmLength)
+	if (!FMath::IsNearlyEqual(SpringArm->TargetArmLength, DesiredArmLength, 1.0f))
 	{
 		SpringArm->TargetArmLength = FMath::FInterpTo(SpringArm->TargetArmLength, DesiredArmLength, DeltaTime, ZoomSmoothness);
 	}


### PR DESCRIPTION
Just a minor change for floating point comparison. Should avoid ticks because they likely will never be equal the way you compare them due to the nature of floating point numbers and interpolation. Also taken into account Unreal units as tolerance level.